### PR TITLE
Use TailwindCSS PurgeCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,12 @@ fin exec craft install
 fin exec npm install
 ```
 
-8. Generate a Tailwind config file
-```sh
-fin exec npx tailwind init
-```
-
-9. Build the asset files
+8. Build the asset files
 ```sh
 fin exec npm run build
 ```
 
-10. That's it!
+9. That's it!
 
 Your new project should now be available at the configured domain and you should see a demo/Hello World page to confirm.
 
@@ -147,11 +142,6 @@ Your new project should now be available at the configured domain and you should
 Install the depdendencies for the build tool
 ```sh
 fin exec npm install
-```
-
-Create a Tailwind config file
-```sh
-fin exec npx tailwind init
 ```
 
 **Production**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "batch-craft-starter",
-  "version": "2.1.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.4",
@@ -1092,9 +1091,9 @@
       }
     },
     "@batch/craft-webpack": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@batch/craft-webpack/-/craft-webpack-1.1.0.tgz",
-      "integrity": "sha512-84t9WwL1mmI9KyjXh31wdaeGuuzWA6EsYyPPCb4+NQmP+X3E2YtvH1caZrTEf+yrr+W7oBnGUmiyU9kjVwfW7Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@batch/craft-webpack/-/craft-webpack-1.2.0.tgz",
+      "integrity": "sha512-/fwNxYUSKlTVA4WzGc5qDqOTXkiNYkd7U3K9ehS2UFBls+yyqmwHsMBEnRpmyVPxZIbPiJ84drHl5DvWKkmNuw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -1326,16 +1325,16 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-      "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.0.tgz",
+      "integrity": "sha512-oh59scth4yf8XUgMJb8ruY7BHm0X5JZDNgGGsVnlOt2XQuq9s2NMllIrN4n70Yds+++bjrTGZ9EoOKraaPKPlg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.3.0",
-        "jest-util": "^26.3.0",
+        "jest-message-util": "^26.5.0",
+        "jest-util": "^26.5.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
@@ -1348,34 +1347,34 @@
       }
     },
     "@jest/core": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-      "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.0.tgz",
+      "integrity": "sha512-hDtgfzYxnrQn54+0JlbqpXM4+bqDfK0ooMlNE4Nn3VBsB4RbmytAn4/kVVIcMa+aYwRr/fwzWuGJwBETVg1sDw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/reporters": "^26.4.1",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/reporters": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.3.0",
-        "jest-config": "^26.4.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-message-util": "^26.3.0",
+        "jest-changed-files": "^26.5.0",
+        "jest-config": "^26.5.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-message-util": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-resolve-dependencies": "^26.4.2",
-        "jest-runner": "^26.4.2",
-        "jest-runtime": "^26.4.2",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
-        "jest-watcher": "^26.3.0",
+        "jest-resolve": "^26.5.0",
+        "jest-resolve-dependencies": "^26.5.0",
+        "jest-runner": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
+        "jest-watcher": "^26.5.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -1435,53 +1434,53 @@
       }
     },
     "@jest/environment": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-      "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.0.tgz",
+      "integrity": "sha512-0F3G9EyZU2NAP0/c/5EqVx4DmldQtRxj0gMl3p3ciSCdyMiCyDmpdE7O0mKTSiFDyl1kU4TfgEVf0r0vMkmYcw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0"
+        "jest-mock": "^26.5.0"
       }
     },
     "@jest/fake-timers": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-      "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.0.tgz",
+      "integrity": "sha512-sQK6xUembaZ0qLnZpSjJJuJiKvyrjCJhaYjbmatFpj5+cM8h2D7YEkeEBC26BMzvF1O3tNM9OL7roqyBmom0KA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/node": "*",
-        "jest-message-util": "^26.3.0",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0"
+        "jest-message-util": "^26.5.0",
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0"
       }
     },
     "@jest/globals": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.0.tgz",
+      "integrity": "sha512-TCKx3XWR9h/yyhQbz0C1sXkK2e8WJOnkP40T9bewNpf2Ahr1UEyKXnCoQO0JCpXFkWGTXBNo1QAgTQ3+LhXfcA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/types": "^26.3.0",
-        "expect": "^26.4.2"
+        "@jest/environment": "^26.5.0",
+        "@jest/types": "^26.5.0",
+        "expect": "^26.5.0"
       }
     },
     "@jest/reporters": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-      "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.0.tgz",
+      "integrity": "sha512-lUl5bbTHflDO9dQa85ZTHasPBVsyC48t9sg/VN2wC3OJryclFNqN4Xfo2FgnNl/pzCnzO2MVgMyIij5aNkod2w==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -1492,10 +1491,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-resolve": "^26.4.0",
-        "jest-util": "^26.3.0",
-        "jest-worker": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-resolve": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-worker": "^26.5.0",
         "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
@@ -1504,6 +1503,12 @@
         "v8-to-istanbul": "^5.0.1"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "is-wsl": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -1512,6 +1517,17 @@
           "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
           }
         },
         "node-notifier": {
@@ -1542,19 +1558,28 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "dev": true,
           "optional": true
         }
       }
     },
     "@jest/source-map": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-      "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+      "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -1563,46 +1588,46 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-      "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.0.tgz",
+      "integrity": "sha512-CaVXxDQi31LPOsz5/+iajNHQlA1Je/jQ8uYH/lCa6Y/UrkO+sDHeEH3x/inbx06PctVDnTwIlCcBvNNbC4FCvQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-      "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.0.tgz",
+      "integrity": "sha512-23oofRXqPEy37HyHWIYf7lzzOqtGBkai5erZiL6RgxlyXE7a0lCihf6b5DfAvcD3yUtbXmh3EzpjJDVH57zQrg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.3.0",
+        "@jest/test-result": "^26.5.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.3.0",
-        "jest-runner": "^26.4.2",
-        "jest-runtime": "^26.4.2"
+        "jest-haste-map": "^26.5.0",
+        "jest-runner": "^26.5.0",
+        "jest-runtime": "^26.5.0"
       }
     },
     "@jest/transform": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-      "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.0.tgz",
+      "integrity": "sha512-Kt4WciOruTyTkJ2DZ+xtZiejRj3v22BrXCYZoGRbI0N6Q6tt2HdsWrrEtn6nlK24QWKC389xKkVk4Xr2gWBZQA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.3.0",
+        "jest-util": "^26.5.0",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1662,9 +1687,9 @@
       }
     },
     "@jest/types": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-      "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+      "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1779,9 +1804,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.3.tgz",
-      "integrity": "sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.4.tgz",
+      "integrity": "sha512-KXUgJ3LIhuQUxZA6jA9Q7ACPM13ztb8GAy2zm6CNHYjmMuCX8wCM/hJcd+qBJMLQPiVbG9wJp3g3WN5OR7cPTg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -1902,9 +1927,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.6.tgz",
-      "integrity": "sha512-BdSe6cmzDEapTBH3s1NKbzu+GyX5bJKraKwVpM2vZF1+EEWxZr0EiA0z9bA5Nux8P+6nKMOZKsXQrj5q/kicfQ==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
+      "integrity": "sha512-wuJiPqSQTVIHsYuumv1PAOBjblSrYA5vyN1nkUDF5HgfuWGz44jQsO22u7PQNkuACGYJE4eU0sybX8CzsySv+Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2"
@@ -2168,9 +2193,9 @@
       "dev": true
     },
     "@types/stack-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+      "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
       "dev": true
     },
     "@types/strip-bom": {
@@ -2866,20 +2891,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -2918,20 +2943,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -3165,16 +3190,16 @@
       }
     },
     "babel-jest": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-      "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.0.tgz",
+      "integrity": "sha512-Cy16ZJrds81C+JASaOIGNlpCeqW3PTOq36owv+Zzwde5NiWz+zNduwxUNF57vxc/3SnIWo8HHqTczhN8GLoXTw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.3.0",
+        "babel-preset-jest": "^26.5.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
@@ -3233,9 +3258,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-      "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+      "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -3267,9 +3292,9 @@
       }
     },
     "babel-preset-current-node-syntax": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-      "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+      "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -3286,12 +3311,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-      "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+      "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.2.0",
+        "babel-plugin-jest-hoist": "^26.5.0",
         "babel-preset-current-node-syntax": "^0.1.3"
       }
     },
@@ -5338,9 +5363,9 @@
       "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
     },
     "css-what": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-      "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz",
+      "integrity": "sha512-wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g==",
       "dev": true
     },
     "css.escape": {
@@ -7210,26 +7235,25 @@
       }
     },
     "expect": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-      "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+      "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.4.2",
-        "jest-message-util": "^26.3.0",
+        "jest-matcher-utils": "^26.5.0",
+        "jest-message-util": "^26.5.0",
         "jest-regex-util": "^26.0.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -9445,16 +9469,57 @@
       }
     },
     "jest": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.0.tgz",
+      "integrity": "sha512-yW1QTkdpxVWTV2M5cOwVdEww8dRGqL5bb7FOG3YQoMtf7oReCEawmU0+tOKkZUSfcOymbXmCfdBQLzuwOLCx0w==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.4.2",
+        "@jest/core": "^26.5.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.4.2"
+        "jest-cli": "^26.5.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
+          "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9475,25 +9540,31 @@
             "resolve-cwd": "^3.0.0"
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "jest-cli": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.0.tgz",
+          "integrity": "sha512-bI0h6GQGbyN0SSZu3nPilwrkrZ8dBC93erwTiEoJ+kGjtNuXsB183hTZ0HCiHLzf88oE0SQB1hYp8RgyytH+Bg==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.4.2",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/core": "^26.5.0",
+            "@jest/test-result": "^26.5.0",
+            "@jest/types": "^26.5.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-config": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-validate": "^26.5.0",
             "prompts": "^2.0.1",
-            "yargs": "^15.3.1"
+            "yargs": "^16.0.3"
           }
         },
         "locate-path": {
@@ -9543,16 +9614,65 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
           "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
+          "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+          "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.0",
+            "escalade": "^3.0.2",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.1",
+            "yargs-parser": "^20.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+          "dev": true
         }
       }
     },
     "jest-changed-files": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-      "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.0.tgz",
+      "integrity": "sha512-RAHoXqxa7gO1rZz88qpsLpzJ2mQU12UaFWadacKHuMbBZwFK+yl0j9YoD9Y/wBpv1ILG2SdCuxFHggX+9VU7qA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
@@ -9601,29 +9721,29 @@
       }
     },
     "jest-config": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-      "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.0.tgz",
+      "integrity": "sha512-OM6eXIEmQXAuonCk8aNPMRjPFcKWa3IIoSlq5BPgIflmQBzM/COcI7XsWSIEPWPa9WcYTJBWj8kNqEYjczmIFw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.4.2",
-        "@jest/types": "^26.3.0",
-        "babel-jest": "^26.3.0",
+        "@jest/test-sequencer": "^26.5.0",
+        "@jest/types": "^26.5.0",
+        "babel-jest": "^26.5.0",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.3.0",
-        "jest-environment-node": "^26.3.0",
+        "jest-environment-jsdom": "^26.5.0",
+        "jest-environment-node": "^26.5.0",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.4.2",
+        "jest-jasmine2": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
+        "jest-resolve": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
         "braces": {
@@ -9785,16 +9905,16 @@
       }
     },
     "jest-each": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-      "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.0.tgz",
+      "integrity": "sha512-+oO3ykDgypHSyyK2xOsh8XDUwMtg3HoJ4wMNFNHxhcACFbUgaCOfLy+eTCn5pIKhtigU3BmkYt7k3MtTb5pJOQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.2"
+        "jest-util": "^26.5.0",
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
         "jest-get-type": {
@@ -9806,32 +9926,32 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-      "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.0.tgz",
+      "integrity": "sha512-Xuqh3bx8egymaJR566ECkiztIIVOIWWPGIxo++ziWyCOqQChUguRCH1hRXBbfINPbb/SRFe7GCD+SunaUgTmCw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0",
-        "jsdom": "^16.2.2"
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jsdom": "^16.4.0"
       }
     },
     "jest-environment-node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-      "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.0.tgz",
+      "integrity": "sha512-LaYl/ek5mb1VDP1/+jMH2N1Ec4fFUhSYmc8EZqigBgMov/2US8U5l7D3IlOf78e+wARUxPxUpTcybVVzAOu3jg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0"
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0"
       }
     },
     "jest-get-type": {
@@ -9841,12 +9961,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-      "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+      "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -9854,9 +9974,9 @@
         "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
-        "jest-serializer": "^26.3.0",
-        "jest-util": "^26.3.0",
-        "jest-worker": "^26.3.0",
+        "jest-serializer": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-worker": "^26.5.0",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
         "walker": "^1.0.7"
@@ -9880,11 +10000,28 @@
             "to-regex-range": "^5.0.1"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
         },
         "micromatch": {
           "version": "4.0.2",
@@ -9894,6 +10031,15 @@
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "to-regex-range": {
@@ -9908,39 +10054,39 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-      "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.0.tgz",
+      "integrity": "sha512-NOA6PLORHTRTROOp5VysKCUVpFAjMMXUS1Xw7FvTMeYK5Ewx4rpxhFqiJ7JT4pENap9g9OuXo4cWR/MwCDTEeQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/source-map": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/source-map": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.4.2",
+        "expect": "^26.5.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.4.2",
-        "jest-matcher-utils": "^26.4.2",
-        "jest-message-util": "^26.3.0",
-        "jest-runtime": "^26.4.2",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.2",
+        "jest-each": "^26.5.0",
+        "jest-matcher-utils": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "pretty-format": "^26.5.0",
         "throat": "^5.0.0"
       }
     },
     "jest-leak-detector": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-      "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.0.tgz",
+      "integrity": "sha512-xZHvvTBbj3gUTtunLjPqP594BT6IUEpwA0AQpEQjVR8eBq8+R3qgU/KhoAcVcV0iqRM6pXtX7hKPZ5mLdynVSQ==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
         "jest-get-type": {
@@ -9952,33 +10098,33 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-      "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+      "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.4.2",
+        "jest-diff": "^26.5.0",
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
         "diff-sequences": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
           "dev": true
         },
         "jest-diff": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.3.0",
+            "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.0"
           }
         },
         "jest-get-type": {
@@ -9990,14 +10136,14 @@
       }
     },
     "jest-message-util": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-      "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+      "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.3.0",
-        "@types/stack-utils": "^1.0.1",
+        "@jest/types": "^26.5.0",
+        "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.2",
@@ -10057,12 +10203,12 @@
       }
     },
     "jest-mock": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-      "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.0.tgz",
+      "integrity": "sha512-8D1UmbnmjdkvTdYygTW26KZr95Aw0/3gEmMZQWkxIEAgEESVDbwDG8ygRlXSY214x9hFjtKezvfQUp36Ogl75w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*"
       }
     },
@@ -10079,98 +10225,21 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-      "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+      "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "chalk": "^4.0.0",
+        "escalade": "^3.1.0",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.3.0",
-        "read-pkg-up": "^7.0.1",
+        "jest-util": "^26.5.0",
         "resolve": "^1.17.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "parse-json": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-          "dev": true,
-          "requires": {
-            "@types/normalize-package-data": "^2.4.0",
-            "normalize-package-data": "^2.5.0",
-            "parse-json": "^5.0.0",
-            "type-fest": "^0.6.0"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.6.0",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-              "dev": true
-            }
-          }
-        },
-        "read-pkg-up": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.1.0",
-            "read-pkg": "^5.2.0",
-            "type-fest": "^0.8.1"
-          }
-        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10180,96 +10249,220 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-      "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.0.tgz",
+      "integrity": "sha512-2e3YdS+dlTY00s0CEiMAa7Ap/mPfPaQV7d6Fzp7BQqHXO/2QhXn/yVTxnxR+dOIo/NOh7pqXZTQSn+2iWwPQQA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.4.2"
+        "jest-snapshot": "^26.5.0"
       }
     },
     "jest-runner": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-      "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.1.tgz",
+      "integrity": "sha512-gFHXehvMZD8qwNzaIl2MDFFI99m4kKk06H2xh2u4IkC+tHYIJjE5J175l9cbL3RuU2slfS2m57KZgcPZfbTavQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.2",
+        "jest-config": "^26.5.0",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.3.0",
-        "jest-leak-detector": "^26.4.2",
-        "jest-message-util": "^26.3.0",
-        "jest-resolve": "^26.4.0",
-        "jest-runtime": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-worker": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-leak-detector": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-resolve": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-worker": "^26.5.0",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-runtime": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-      "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.0.tgz",
+      "integrity": "sha512-CujjQWpMcsvSg0L+G3iEz6s7Th5IbiZseAaw/5R7Eb+IfnJdyPdjJ+EoXNV8n07snvW5nZTwV9QIfy6Vjris8A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/globals": "^26.4.2",
-        "@jest/source-map": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/globals": "^26.5.0",
+        "@jest/source-map": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-message-util": "^26.3.0",
-        "jest-mock": "^26.3.0",
+        "jest-config": "^26.5.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-mock": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
+        "jest-resolve": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
+          "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "slash": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
           "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
           "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
+          "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.0.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+          "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.0",
+            "escalade": "^3.0.2",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.1",
+            "yargs-parser": "^20.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+          "dev": true
         }
       }
     },
     "jest-serializer": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-      "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+      "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -10277,44 +10470,45 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-      "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
+      "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
+        "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.4.2",
+        "expect": "^26.5.0",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.4.2",
+        "jest-diff": "^26.5.0",
         "jest-get-type": "^26.3.0",
-        "jest-haste-map": "^26.3.0",
-        "jest-matcher-utils": "^26.4.2",
-        "jest-message-util": "^26.3.0",
-        "jest-resolve": "^26.4.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-matcher-utils": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-resolve": "^26.5.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.4.2",
+        "pretty-format": "^26.5.0",
         "semver": "^7.3.2"
       },
       "dependencies": {
         "diff-sequences": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
           "dev": true
         },
         "jest-diff": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.3.0",
+            "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.0"
           }
         },
         "jest-get-type": {
@@ -10332,12 +10526,12 @@
       }
     },
     "jest-util": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-      "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+      "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -10391,17 +10585,17 @@
       }
     },
     "jest-validate": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-      "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.0.tgz",
+      "integrity": "sha512-603+CHUJD4nAZ+tY/A+wu3g8KEcBey2a7YOMU9W8e4u7mCezhaDasw20ITaZHoR2R2MZhThL6jApPSj0GvezrQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
         "camelcase": {
@@ -10419,17 +10613,17 @@
       }
     },
     "jest-watcher": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-      "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.0.tgz",
+      "integrity": "sha512-INLKhpc9QbO5zy2HkS1CJUncByrCLFDZQOY30d9ojiuGO02ofL1BygDRDRtFvT/oWSZ8Y0fbkrr1oXU2ay/MqA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.3.0",
+        "jest-util": "^26.5.0",
         "string-length": "^4.0.1"
       }
     },
@@ -11270,9 +11464,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.2.tgz",
-      "integrity": "sha512-h2LknfX4U1kScXxH8xE9LCOqT5B+068EAj36qicMb8l4dqdJoyHcmWmpd+ueyZfgu/POvIn+teoUnTtei2ikug==",
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
+      "integrity": "sha512-n9BA8LonkOkW1/zn+IbLPQmovsL0wMb9yx75fMJQZf2X1Zoec9yTZtyMePcyu19wPkmFbzZZA6fLTotpFhQsOA==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
@@ -11861,30 +12055,31 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "es-abstract": "^1.18.0-next.1"
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -11936,20 +12131,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -11967,20 +12162,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -12009,20 +12204,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -12626,9 +12821,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
-      "integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.27",
@@ -13063,13 +13258,13 @@
       }
     },
     "postcss-loader": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.0.2.tgz",
-      "integrity": "sha512-u7Qoa6GSPIeg9/hHbNnXspzuD5jjCIWKgk1fJ/gGJPS0uaj6Whk2zjXhDAiHZyYSrDmIzUQk7GgwRF22eRIQGQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-4.0.3.tgz",
+      "integrity": "sha512-jHboC/AOnJLPu8/974hODCJ/rNAa2YhhJOclUeuRlAmFpKmEcBY6az8y1ejHyYc2LThzPl8qPRekh2Yz3CiRKA==",
       "dev": true,
       "requires": {
         "cosmiconfig": "^7.0.0",
-        "klona": "^2.0.3",
+        "klona": "^2.0.4",
         "loader-utils": "^2.0.0",
         "schema-utils": "^2.7.1",
         "semver": "^7.3.2"
@@ -13933,24 +14128,23 @@
       }
     },
     "pretty-format": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-      "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+      "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "ansi-regex": "^5.0.0",
         "ansi-styles": "^4.0.0",
         "react-is": "^16.12.0"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -14461,20 +14655,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -16081,13 +16275,13 @@
       }
     },
     "style-loader": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.2.1.tgz",
-      "integrity": "sha512-ByHSTQvHLkWE9Ir5+lGbVOXhxX10fbprhLvdg96wedFZb4NDekDPxVKv5Fwmio+QcMlkkNfuK+5W1peQ5CUhZg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.3.0.tgz",
+      "integrity": "sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==",
       "dev": true,
       "requires": {
         "loader-utils": "^2.0.0",
-        "schema-utils": "^2.6.6"
+        "schema-utils": "^2.7.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -16196,12 +16390,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -16941,9 +17134,9 @@
           }
         },
         "terser": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.3.tgz",
-          "integrity": "sha512-vRQDIlD+2Pg8YMwVK9kMM3yGylG95EIwzBai1Bw7Ot4OBfn3VP1TZn3EWx4ep2jERN/AmnVaTiGuelZSN7ds/A==",
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.3.4.tgz",
+          "integrity": "sha512-dxuB8KQo8Gt6OVOeLg/rxfcxdNZI/V1G6ze1czFUzPeCFWZRtvZMgSzlZZ5OYBZ4HoG607F6pFPNLekJyV+yVw==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -17607,20 +17800,20 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -18097,9 +18290,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
           "dev": true
         },
         "cacache": {
@@ -18762,9 +18955,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+      "integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Batch's Craft Starter",
   "scripts": {
     "dev": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js",
-    "build": "webpack --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.prod.js",
+    "build": "NODE_ENV=production webpack --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.prod.js",
     "dev-legacy": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js --env.BUILD_TYPE=legacy",
     "dev-combined": "webpack-dev-server --progress --hide-modules --config=node_modules/@batch/craft-webpack/webpack.dev.js --env.BUILD_TYPE=combined",
     "test": "jest"
@@ -48,15 +48,17 @@
     "vue": "^2.6.12"
   },
   "devDependencies": {
-    "@batch/craft-webpack": "^1.0.0",
-    "@testing-library/dom": "^7.24.3",
-    "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/user-event": "^12.1.6",
-    "@testing-library/vue": "^5.1.0",
+    "@babel/core": "^7.11.6",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+    "@babel/preset-env": "^7.11.5",
+    "@batch/craft-webpack": "^1.2.0",
+    "@testing-library/dom": "^7.24.4",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/user-event": "^12.1.7",
+    "@testing-library/vue": "^5.1.0",
     "babel-core": "^7.0.0-bridge.0",
-    "babel-jest": "^26.3.0",
-    "jest": "^26.4.2",
+    "babel-jest": "^26.5.0",
+    "jest": "^26.5.0",
     "vue-jest": "^3.0.7"
   },
   "author": "Josh Smith <josh@batch.nz>",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  future: {
+    removeDeprecatedGapUtilities: true,
+    purgeLayersByDefault: true,
+  },
+  purge: [
+    "./templates/**/*.{twig,html}",
+    "./src/vue/**/*.{vue,html}"
+  ],
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+}


### PR DESCRIPTION
## Description

I've updated the build npm script to set the NODE_ENV to production when running the build pipeline. This lets Tailwind know it should purge CSS.

I've also included a default `tailwind.config.js` file as I think it's important to set the purge default paths for the craft-starter (as well as opt in to the recommended future features).

Docs have also been updated to remove the `npx tailwind init` step.

Depends on: https://github.com/batchnz/craft-webpack/pull/5

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How to test
- [ ] Update the `craft-webpack` package once the above pull request is merged.
- [ ] Run `npm run build` and check Tailwind styles are purged.

## Checklist:

- [X] My branch is up to date with master
- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
