### PR TITLE
Added default formatting config for vscode for php, js and vue files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,10 @@
 {
+  "eslint.format.enable": true,
+  
+  // PHP CS Fixer doesn't have a PSR12 ruleset yet, but the PHP CS Fixer ruleset is similar
+  "php-cs-fixer.rules": "@PhpCsFixer,declare_strict_types",
+  "php-cs-fixer.allowRisky": true,
+
   "[html]": {
     "editor.formatOnSave": true
   },
@@ -6,12 +12,18 @@
     "editor.formatOnSave": true
   },
   "[javascript]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   },
   "[vue]": {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[json]": {
     "editor.formatOnSave": true
-  }
+  },
+  "[php]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "junstyle.php-cs-fixer"
+  },
 }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "vlucas/phpdotenv": "^3.4.0"
   },
   "require-dev": {
+    "friendsofphp/php-cs-fixer": "^2.13",
     "yiisoft/yii2-shell": "^2.0.3"
   },
   "autoload": {


### PR DESCRIPTION
## Description

Includes default formatter config for VSCode

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Works on my machine!

## Checklist:

- [ ] My branch is up to date with master
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings and debugging code has been removed
