### PR TITLE
fix: eslint issues

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,5 +15,15 @@
   "env": {
     "node": true,
     "browser": true
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["src"]
+      },
+      "webpack": {
+        "config": "node_modules/@batch/craft-webpack/webpack.dev.js"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "@testing-library/vue": "^5.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^26.5.2",
+    "eslint-import-resolver-webpack": "^0.13.0",
     "jest": "^26.5.3",
+    "prettier": "^2.1.2",
     "vue-jest": "^3.0.7"
   },
   "author": "Josh Smith <josh@batch.nz>",

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,12 +12,12 @@ const main = async () => {
 
   return {
     Vue,
-    axios
+    axios,
   };
 };
 
 // Execute async function
-main().then(components => {
+main().then((components) => {
   const { Vue, axios } = components;
 
   // Add a global instance of axios to Vue
@@ -29,11 +29,11 @@ main().then(components => {
     el: "#app",
     components: {
       HelloWorld: () =>
-        import(/* webpackChunkName: "HelloWorld" */ "../vue/HelloWorld.vue")
+        import(/* webpackChunkName: "HelloWorld" */ "../vue/HelloWorld.vue"),
     },
     mounted() {
       window.app.emit("vue-mounted");
-    }
+    },
   });
   /* eslint-enable no-unused-vars */
 });


### PR DESCRIPTION
## Description

This resolves a few temporary issues with the eslint setup including:

1. Prettier peer dependency not being met
2. Eslint unable to resolve aliased imports via webpack

**Note:** this is a temporary fix as I've done a refactor sitting as `v1.5.0` on the craft-webpack repo. This is currently unreleased on npm due to finding a few issues last minute 😢 so may need to be reverted in the future.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested locally with aliased imports in `app.js`.