### PR TITLE
Added svg src directory and Jest transformer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -178,6 +178,7 @@ module.exports = {
         presets: ["@babel/preset-env"]
       }
     ],
+    ".*\\.(svg)$": "<rootDir>/src/svg/transform.js",
     ".*\\.(vue)$": "vue-jest"
   }
 

--- a/src/svg/transform.js
+++ b/src/svg/transform.js
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-extraneous-dependencies */
+const vueJest = require("vue-jest/lib/template-compiler");
+
+module.exports = {
+  process(content) {
+    const { render } = vueJest({
+      content,
+      attrs: {
+        functional: false
+      }
+    });
+
+    return `module.exports = { render: ${render} }`;
+  }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     critical: path.resolve(
       settings.paths.working,
       `${settings.paths.src.js}/critical.js`
-    ),
+    )
   },
   // Add your Webpack aliases here.
   // We've provided a set of defaults mapped to the /src directory.
@@ -24,6 +24,7 @@ module.exports = {
       "#js": path.resolve(__dirname, "src/js"),
       "#css": path.resolve(__dirname, "src/css"),
       "#fonts": path.resolve(__dirname, "src/fonts"),
-    },
-  },
+      "#svg": path.resolve(__dirname, "src/svg")
+    }
+  }
 };


### PR DESCRIPTION
## Description

Creates a new SVG src directory for putting project SVGs in, and adds a jest transformer for SVG files. Two reasons for this:

1. We usually keep SVG in the templates directory at the moment, but often import them into Vue, leading to tricky relative imports. It would be nice to have an alias for referencing them with. As they are shared between Vue and Twig, it seems nicer to keep them in the src folder and reference them either via a webpack alias or twigpack.

2. I have to recreate the svg transformer I add in this PR in every project (nobody has created an npm package for it yet, amazingly). I could create the package I suppose, but creating a package for five lines of code I didn't write seems a bit off

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Test importing an SVG into a Vue file and running jest. Test should pass

## Checklist:

- [ ] My branch is up to date with master
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings and debugging code has been removed
